### PR TITLE
優化 linebot_connect.py

### DIFF
--- a/linebot_connect.py
+++ b/linebot_connect.py
@@ -1,44 +1,47 @@
+import json
+
 from flask import Flask, request, abort
 from linebot import LineBotApi, WebhookHandler
 from linebot.exceptions import InvalidSignatureError
 from linebot.models import MessageEvent, TextMessage, TextSendMessage
+
 from main import reply_message
-import json
 
-with open('key.json','r') as f:
+# 讀取金鑰設定檔
+with open('key.json', 'r') as f:
     key = json.load(f)
-
-
-#登入https://developers.line.biz/zh-hant/
 
 app = Flask(__name__)
 
 # 設定 Channel Access Token 和 Channel Secret
-
-line_bot_api = LineBotApi( key["line_Channel_access_token"])
+line_bot_api = LineBotApi(key["line_Channel_access_token"])
 handler = WebhookHandler(key["line_Channel_secret"])
+
 
 @app.route("/callback", methods=['POST'])
 def callback():
-    # 獲取 X-Line-Signature 標頭
-    signature = request.headers['X-Line-Signature']
-    # 獲取請求的 body
+    """處理來自 LINE 平台的 callback 請求."""
+    # 以安全方式取得 X-Line-Signature 標頭
+    signature = request.headers.get('X-Line-Signature')
+    # 取得請求的 body
     body = request.get_data(as_text=True)
 
     try:
-        # 驗證請求並處理事件
         handler.handle(body, signature)
     except InvalidSignatureError:
         abort(400)
 
     return 'OK'
 
-# 處理文字訊息事件
+
 @handler.add(MessageEvent, message=TextMessage)
 def handle_message(event: MessageEvent):
-    replay_token = reply_message(event)
+    """處理收到的文字訊息事件."""
+    # 呼叫 reply_message 取得要回覆的訊息內容
     message = reply_message(event)
-    line_bot_api.reply_message(replay_token,message)
+    # 使用 event.reply_token 來回覆訊息
+    line_bot_api.reply_message(event.reply_token, message)
+
 
 if __name__ == "__main__":
     app.run(port=8000)


### PR DESCRIPTION
o3-mini

優化與修改說明

1. **PEP 8 排版與命名規範**  
   - **引入順序**：將標準函式庫（`json`）放在最前，再依序加入第三方套件與自訂模組，符合 PEP 8 的 import 排序規範。  
   - **空白與縮排**：統一在逗號後加上空格，例如 `with open('key.json', 'r') as f:`。  
   - **函式與模組說明**：為主要的函式（`callback` 與 `handle_message`）添加了 docstring，以提升程式可讀性與維護性。

2. **Bug 修正與潛在問題防範**  
   - **重複呼叫 reply_message**：原程式在 `handle_message` 函式中呼叫 `reply_message(event)` 兩次，分別將結果賦值給 `replay_token` 與 `message`。這不僅有命名上的錯誤（應為 reply 而非 replay），也會導致兩次相同的計算（若該函式耗時或有副作用可能產生問題）。優化後僅呼叫一次，並直接利用 `event.reply_token` 作為回覆標記。  
   - **標頭取得方式**：使用 `request.headers.get('X-Line-Signature')`，較直接存取並可避免因標頭不存在而拋出 KeyError。

3. **其他優化**  
   - **註解與說明**：中文註解進行了部分調整，使程式邏輯更易理解。  
   - **命名一致性**：統一使用 `reply` 的正確拼字，避免因拼寫錯誤引起混淆或 bug。